### PR TITLE
Fix when .Values.serviceName not present

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FFC Kubernetes platform
 type: library
-version: 1.0.2
+version: 1.0.3

--- a/ffc-helm-library/templates/_deployment.yaml
+++ b/ffc-helm-library/templates/_deployment.yaml
@@ -23,8 +23,10 @@ spec:
         redeployOnChange: {{ required (printf $requiredMsg "deployment.redeployOnChange") .Values.deployment.redeployOnChange | quote }}
     spec:
       priorityClassName: {{ required (printf $requiredMsg "deployment.priorityClassName") .Values.deployment.priorityClassName | quote }}
+      {{- if .Values.serviceAccount }}
       {{- if .Values.serviceAccount.roleArn }}
       serviceAccountName: {{ .Values.serviceAccount.name | quote }}
+      {{- end }}
       {{- end }}
       restartPolicy: {{ required (printf $requiredMsg "deployment.restartPolicy") .Values.deployment.restartPolicy | quote }}
       {{- if .Values.deployment.imagePullSecret }}


### PR DESCRIPTION
Fix issue introduced with check for serviceName.roleArn which breaks charts without serviceName