### PR TITLE
Match Azure Identity by namespace

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FFC Kubernetes platform
 type: library
-version: 1.2.6
+version: 1.2.7

--- a/ffc-helm-library/templates/_azure-identity.yaml
+++ b/ffc-helm-library/templates/_azure-identity.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ required (printf $requiredMsg "name") .Values.name }}-identity
   namespace: {{ required (printf $requiredMsg "namespace") .Values.namespace | quote }}
   labels: {{- include "ffc-helm-library.labels" . | nindent 4 }}
+  annotations:
+    aadpodidentity.k8s.io/Behavior: namespaced
 spec:
   type: 0
   resourceID: {{ required (printf $requiredMsg "azureIdentity.resourceID") .Values.azureIdentity.resourceID | quote }}


### PR DESCRIPTION
By default aad-pod-identity matches across namespaces. We want to match only within the namespace: https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.namespaced.md