### PR TITLE
Adding workload identity configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ A K8s `ServiceAccount` object.
 
 A basic usage of this object template would involve the creation of `templates/service-account.yaml` in the parent Helm chart (e.g. `ffc-microservice`) containing:
 
+A service account is needed when the service needs to use Workload Identity to connect to the resources in Azure
+After adding the service account, `workloadIdentity: true` needs to be added to the `value.yaml` file. By activating Workload Identity, the Pod Identity will be disabled. 
+
 ```yaml
 {{- include "ffc-helm-library.service-account" (list . "ffc-microservice.service-account") -}}
 {{- define "ffc-microservice.service-account" -}}

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 4.6.0
+version: 4.7.0

--- a/ffc-helm-library/templates/_cron-job.yaml
+++ b/ffc-helm-library/templates/_cron-job.yaml
@@ -16,7 +16,9 @@ spec:
         metadata:
           labels:
             {{- include "ffc-helm-library.labels" . | nindent 12 }}
-            {{- if .Values.azureIdentity }}
+            {{- if and (.Values.azureIdentity) (.Values.workloadIdentity) }}
+            azure.workload.identity/use: "true"
+            {{- else if .Values.azureIdentity }}
             aadpodidbinding: {{ .Chart.Name }}-identity-selector
             {{- end }}
         spec:

--- a/ffc-helm-library/templates/_deployment.yaml
+++ b/ffc-helm-library/templates/_deployment.yaml
@@ -18,7 +18,9 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace | quote }}
       labels:
-        {{- if .Values.azureIdentity }}
+        {{- if and (.Values.azureIdentity) (.Values.workloadIdentity) }}
+        azure.workload.identity/use: "true"
+        {{- else if .Values.azureIdentity }}
         aadpodidbinding: {{ .Chart.Name }}-identity-selector
         {{- end }}
         {{- include "ffc-helm-library.labels" . | nindent 8 }}

--- a/ffc-helm-library/templates/_service-account.yaml
+++ b/ffc-helm-library/templates/_service-account.yaml
@@ -1,7 +1,12 @@
 {{- define "ffc-helm-library.service-account.tpl" -}}
+{{- $requiredMsg := include "ffc-helm-library.default-check-required-msg" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if and (.Values.azureIdentity) (.Values.workloadIdentity) }}
+  annotations:
+    azure.workload.identity/client-id: {{ required (printf $requiredMsg "azureIdentity.clientID") .Values.azureIdentity.clientID | quote }}
+  {{- end -}}
   name: {{ .Chart.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:

--- a/ffc-helm-library/templates/_statefulset.yaml
+++ b/ffc-helm-library/templates/_statefulset.yaml
@@ -17,7 +17,9 @@ spec:
   template:
     metadata:
       labels:
-        {{- if .Values.azureIdentity }}
+        {{- if and (.Values.azureIdentity) (.Values.workloadIdentity) }}
+        azure.workload.identity/use: "true"
+        {{- else if .Values.azureIdentity }}
         aadpodidbinding: {{ .Chart.Name }}-identity-selector
         {{- end }}
         {{- include "ffc-helm-library.labels" . | nindent 8 }}


### PR DESCRIPTION
With adding `workloadIdentity: ture` to the chart value, the application will use workload identity instead of pod identity
in the next versions after upgrading all applications, the pod identity will completely remove from the chart.