### PR TITLE
Changing the Chart.name to Chart.Name

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 4.7.0
+version: 4.7.1

--- a/ffc-helm-library/templates/_role-binding.yaml
+++ b/ffc-helm-library/templates/_role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Chart.name }}-developer-1-admin-rolebinding
+  name: {{ .Chart.Name }}-developer-1-admin-rolebinding
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}

--- a/ffc-helm-library/templates/_secret.yaml
+++ b/ffc-helm-library/templates/_secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Chart.name | quote }}
+  name: {{ .Chart.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}

--- a/ffc-helm-library/templates/_service-account.yaml
+++ b/ffc-helm-library/templates/_service-account.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     azure.workload.identity/client-id: {{ required (printf $requiredMsg "azureIdentity.clientID") .Values.azureIdentity.clientID | quote }}
   {{- end -}}
-  name: {{ .Chart.name | quote }}
+  name: {{ .Chart.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}

--- a/ffc-helm-library/templates/_service.yaml
+++ b/ffc-helm-library/templates/_service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.name | quote}}
+  name: {{ .Chart.Name | quote}}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}

--- a/ffc-helm-library/templates/_vertical-pod-autoscaler.yaml
+++ b/ffc-helm-library/templates/_vertical-pod-autoscaler.yaml
@@ -3,7 +3,7 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata: 
-  name: {{ .Chart.name | quote }}
+  name: {{ .Chart.Name | quote }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
@@ -11,7 +11,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Chart.name | quote }}
+    name: {{ .Chart.Name | quote }}
   updatePolicy: 
     updateMode: {{ required (printf $requiredMsg "updateMode") .Values.deployment.updateMode }}
 {{- end }}


### PR DESCRIPTION
To fix the following error
```
error calling include: template: ffc-demo-apply/charts/ffc-helm-library/templates/_service-account.yaml:10:17: executing "ffc-helm-library.service-account.tpl" at <.Chart.name>: can't evaluate field name in type interface {}
```
change the Chart.name to Chart.Name