### PR TITLE
Add support for additional Ingress 

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 4.7.7
+version: 4.8.7

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.0
+version: 5.0.1

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.1
+version: 5.0.2

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 4.8.7
+version: 4.8.8

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.2
+version: 5.0.3

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.4
+version: 5.0.5

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.3
+version: 5.0.4

--- a/ffc-helm-library/templates/_azure-ingress-oss.yaml
+++ b/ffc-helm-library/templates/_azure-ingress-oss.yaml
@@ -1,13 +1,12 @@
-{{- define "ffc-helm-library.azure-ingress.main.tpl" -}}
+{{- define "ffc-helm-library.azure-ingress.oss.tpl" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Chart.Name | quote }}
+  name: {{ print .Chart.Name "-oss" }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{  .Values.ingress.class | default "nginx" | quote }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -15,6 +14,7 @@ metadata:
     nginx.org/mergeable-ingress-type: {{ .Values.ingress.type | quote }}
     {{- end }}
 spec:
+  ingressClassName: "nginx-oss"
   rules:
 {{- if .Values.ingress.endpoint }}
   {{- if .Values.pr }}

--- a/ffc-helm-library/templates/_azure-ingress-oss.yaml
+++ b/ffc-helm-library/templates/_azure-ingress-oss.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
+    kubernetes.io/ingress.class: "nginx-oss"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;

--- a/ffc-helm-library/templates/_azure-ingress-oss.yaml
+++ b/ffc-helm-library/templates/_azure-ingress-oss.yaml
@@ -39,3 +39,6 @@ spec:
               number: 80
 {{- end }}
 {{- end }}
+{{- define "ffc-helm-library.azure-ingress.oss" -}}
+{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.oss.tpl") -}}
+{{- end -}}

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -7,6 +7,47 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
+    kubernetes.io/ingress.class: {{  .Values.ingress.class | default "nginx" | quote }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+      grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
+    {{- if and (.Values.ingress.type) (not .Values.pr) }}
+    nginx.org/mergeable-ingress-type: {{ .Values.ingress.type | quote }}
+    {{- end }}
+spec:
+  rules:
+{{- if .Values.ingress.endpoint }}
+  {{- if .Values.pr }}
+  - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
+  {{ else }}
+  - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
+  {{- end }}
+  {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+    http:
+  {{- end }}
+{{ else }}
+  - http:
+{{- end }}
+{{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+      paths:
+      - path: {{ .Values.ingress.path | default "/" | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name | quote }}
+            port:
+              number: 80
+{{- end }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name | quote }}-oss
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ffc-helm-library.labels" . | nindent 4 }}
+  annotations:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{  .Values.ingress.class | default "nginx" | quote }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -15,6 +14,7 @@ metadata:
     nginx.org/mergeable-ingress-type: {{ .Values.ingress.type | quote }}
     {{- end }}
 spec:
+  ingressClassName: nginx-oss
   rules:
 {{- if .Values.ingress.endpoint }}
   {{- if .Values.pr }}

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -39,3 +39,6 @@ spec:
               number: 80
 {{- end }}
 {{- end }}
+{{- define "ffc-helm-library.azure-ingress.main" -}}
+{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.main.tpl") -}}
+{{- end -}}

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -38,7 +38,6 @@ spec:
             port:
               number: 80
 {{- end }}
-{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class | default "nginx" | quote }}
+    kubernetes.io/ingress.class: {{  .Values.ingress.class | default "nginx" | quote }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -16,27 +16,27 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- if .Values.ingress.endpoint }}
-    {{- if .Values.pr }}
-    - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
-    {{- else }}
-    - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
-    {{- end }}
-    {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-      http:
-    {{- end }}
-  {{- else }}
-    - http:
+{{- if .Values.ingress.endpoint }}
+  {{- if .Values.pr }}
+  - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
+  {{ else }}
+  - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
   {{- end }}
   {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-        paths:
-        - path: {{ .Values.ingress.path | default "/" | quote }}
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ .Chart.Name | quote }}
-              port:
-                number: 80
+    http:
+  {{- end }}
+{{ else }}
+  - http:
+{{- end }}
+{{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+      paths:
+      - path: {{ .Values.ingress.path | default "/" | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name | quote }}
+            port:
+              number: 80
   {{- end }}
 {{- end }}
 
@@ -60,32 +60,31 @@ metadata:
 spec:
   ingressClassName: nginx-oss
   rules:
-  {{- if .Values.ingress.endpoint }}
-    {{- if .Values.pr }}
-    - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
-    {{- else }}
-    - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
-    {{- end }}
-    {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-      http:
-    {{- end }}
-  {{- else }}
-    - http:
+{{- if .Values.ingress.endpoint }}
+  {{- if .Values.pr }}
+  - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
+  {{ else }}
+  - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
   {{- end }}
   {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-        paths:
-        - path: {{ .Values.ingress.path | default "/" | quote }}
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ .Chart.Name | quote }}
-              port:
-                number: 80
+    http:
+  {{- end }}
+{{ else }}
+  - http:
+{{- end }}
+{{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+      paths:
+      - path: {{ .Values.ingress.path | default "/" | quote }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name | quote }}
+            port:
+              number: 80
   {{- end }}
 {{- end }}
 
 ---
-
 {{- define "ffc-helm-library.azure-ingress" -}}
 {{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.primary.tpl") }}
 ---

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -1,4 +1,4 @@
-{{- define "ffc-helm-library.azure-ingress.tpl" -}}
+{{- define "ffc-helm-library.azure-ingress.primary.tpl" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{  .Values.ingress.class | default "nginx" | quote }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.class | default "nginx" | quote }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
@@ -16,29 +16,33 @@ metadata:
     {{- end }}
 spec:
   rules:
-{{- if .Values.ingress.endpoint }}
-  {{- if .Values.pr }}
-  - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
-  {{ else }}
-  - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
+  {{- if .Values.ingress.endpoint }}
+    {{- if .Values.pr }}
+    - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
+    {{- else }}
+    - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
+    {{- end }}
+    {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+      http:
+    {{- end }}
+  {{- else }}
+    - http:
   {{- end }}
   {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-    http:
+        paths:
+        - path: {{ .Values.ingress.path | default "/" | quote }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Chart.Name | quote }}
+              port:
+                number: 80
   {{- end }}
-{{ else }}
-  - http:
 {{- end }}
-{{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-      paths:
-      - path: {{ .Values.ingress.path | default "/" | quote }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Chart.Name | quote }}
-            port:
-              number: 80
-{{- end }}
+
 ---
+
+{{- define "ffc-helm-library.azure-ingress.oss.tpl" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -56,29 +60,34 @@ metadata:
 spec:
   ingressClassName: nginx-oss
   rules:
-{{- if .Values.ingress.endpoint }}
-  {{- if .Values.pr }}
-  - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
-  {{ else }}
-  - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
+  {{- if .Values.ingress.endpoint }}
+    {{- if .Values.pr }}
+    - host: {{ .Chart.Name }}-{{ .Values.pr }}.{{ .Values.ingress.server }}
+    {{- else }}
+    - host: {{ .Values.ingress.endpoint }}.{{ .Values.ingress.server }}
+    {{- end }}
+    {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
+      http:
+    {{- end }}
+  {{- else }}
+    - http:
   {{- end }}
   {{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-    http:
+        paths:
+        - path: {{ .Values.ingress.path | default "/" | quote }}
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Chart.Name | quote }}
+              port:
+                number: 80
   {{- end }}
-{{ else }}
-  - http:
 {{- end }}
-{{- if or (not .Values.ingress.type) (ne (.Values.ingress.type | toString) "master") }}
-      paths:
-      - path: {{ .Values.ingress.path | default "/" | quote }}
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Chart.Name | quote }}
-            port:
-              number: 80
-{{- end }}
-{{- end }}
+
+---
+
 {{- define "ffc-helm-library.azure-ingress" -}}
-{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.tpl") -}}
+{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.primary.tpl") }}
+---
+{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.oss.tpl") }}
 {{- end -}}

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -1,4 +1,4 @@
-{{- define "ffc-helm-library.azure-ingress.primary.tpl" -}}
+{{- define "ffc-helm-library.azure-ingress.tpl" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -37,16 +37,12 @@ spec:
             name: {{ .Chart.Name | quote }}
             port:
               number: 80
-  {{- end }}
 {{- end }}
-
 ---
-
-{{- define "ffc-helm-library.azure-ingress.oss.tpl" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Chart.Name | quote }}-oss
+  name: {{ print .Chart.Name "-oss" }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
@@ -81,12 +77,8 @@ spec:
             name: {{ .Chart.Name | quote }}
             port:
               number: 80
-  {{- end }}
 {{- end }}
-
----
+{{- end }}
 {{- define "ffc-helm-library.azure-ingress" -}}
-{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.primary.tpl") }}
----
-{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.oss.tpl") }}
+{{- include "ffc-helm-library.util.merge" (append . "ffc-helm-library.azure-ingress.tpl") -}}
 {{- end -}}

--- a/ffc-helm-library/templates/_azure-inress-merge.yaml
+++ b/ffc-helm-library/templates/_azure-inress-merge.yaml
@@ -1,6 +1,5 @@
 {{- define "ffc-helm-library.azure-ingress" -}}
-{{- $ctx := index . 0 }}
-{{- $oss := include "ffc-helm-library.azure-ingress.oss.tpl" $ctx }}
-{{- $main := include "ffc-helm-library.azure-ingress.main.tpl" $ctx }}
-{{- printf "%s\n---\n%s" $oss $main }}
+{{- include "ffc-helm-library.azure-ingress.main" . }}
+--- 
+{{- include "ffc-helm-library.azure-ingress.oss" . }} 
 {{- end -}}

--- a/ffc-helm-library/templates/_azure-inress-merge.yaml
+++ b/ffc-helm-library/templates/_azure-inress-merge.yaml
@@ -1,0 +1,6 @@
+{{- define "ffc-helm-library.azure-ingress" -}}
+{{- $ctx := index . 0 }}
+{{- $oss := include "ffc-helm-library.azure-ingress.oss.tpl" $ctx }}
+{{- $main := include "ffc-helm-library.azure-ingress.main.tpl" $ctx }}
+{{- printf "%s\n---\n%s" $oss $main }}
+{{- end -}}

--- a/ffc-helm-library/templates/_ingress.yaml
+++ b/ffc-helm-library/templates/_ingress.yaml
@@ -7,8 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class | default "nginx" | quote }}
 spec:
-  ingressClassName: nginx-oss
   rules:
 {{- if .Values.ingress.endpoint }}
   {{- if .Values.pr }}

--- a/ffc-helm-library/templates/_ingress.yaml
+++ b/ffc-helm-library/templates/_ingress.yaml
@@ -7,9 +7,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class | default "nginx" | quote }}
 spec:
+  ingressClassName: nginx-oss
   rules:
 {{- if .Values.ingress.endpoint }}
   {{- if .Values.pr }}


### PR DESCRIPTION
Addition of a new ingress for the application. Moving the ingress class from annotation to spec.ingressClassName.

> Before the IngressClass resource and ingressClassName field were added in Kubernetes 1.18, Ingress classes were specified with a kubernetes.io/ingress.class annotation on the Ingress. This annotation was never formally defined, but was widely supported by Ingress controllers.

> The newer ingressClassName field on Ingresses is a replacement for that annotation, but is not a direct equivalent. While the annotation was generally used to reference the name of the Ingress controller that should implement the Ingress, the field is a reference to an IngressClass resource that contains additional Ingress configuration, including the name of the Ingress controller.

Source: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/ingress_class/#deprecated-kubernetesioingressclass-annotation