### PR TITLE
Add ingress class name to original ingress

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.0.5
+version: 5.0.6

--- a/ffc-helm-library/templates/_azure-ingress.yaml
+++ b/ffc-helm-library/templates/_azure-ingress.yaml
@@ -15,6 +15,7 @@ metadata:
     nginx.org/mergeable-ingress-type: {{ .Values.ingress.type | quote }}
     {{- end }}
 spec:
+  ingressClassName: {{  .Values.ingress.class | default "nginx" | quote }}
   rules:
 {{- if .Values.ingress.endpoint }}
   {{- if .Values.pr }}


### PR DESCRIPTION
For completeness setting spec.ingressClassName on the original ingress resource. 