### PR TITLE
switch to workload id

### DIFF
--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.1.0
+version: 5.1.1

--- a/ffc-helm-library/templates/_secret-provider-class.yaml
+++ b/ffc-helm-library/templates/_secret-provider-class.yaml
@@ -1,4 +1,5 @@
 {{- define "ffc-helm-library.secret-provider-class.tpl" -}}
+{{- $requiredMsg := include "ffc-helm-library.default-check-required-msg" . -}}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -10,7 +11,7 @@ spec:
   provider: "azure"
   parameters:
     usePodIdentity: {{ .Values.secretProviderClass.azure.usePodIdentity | default "false" | quote }}
-    clientID: {{ .Values.secretProviderClass.azure.clientID | quote }}
+    clientID: {{ required (printf $requiredMsg "azureIdentity.clientID") .Values.azureIdentity.clientID | quote }}
     keyvaultName: {{ .Values.secretProviderClass.azure.keyvaultName | quote }}
     objects: |
       array:

--- a/ffc-helm-library/templates/_secret-provider-class.yaml
+++ b/ffc-helm-library/templates/_secret-provider-class.yaml
@@ -7,12 +7,10 @@ metadata:
   labels:
     {{- include "ffc-helm-library.labels" . | nindent 4 }}
 spec:
-  provider: {{ .Values.secretProviderClass.provider | default "azure" | quote }}
+  provider: "azure"
   parameters:
-    {{- if eq .Values.secretProviderClass.provider "azure" }}
     usePodIdentity: {{ .Values.secretProviderClass.azure.usePodIdentity | default "false" | quote }}
-    useVMManagedIdentity: {{ .Values.secretProviderClass.azure.useVMManagedIdentity | default "true" | quote }}
-    userAssignedIdentityID: {{ .Values.secretProviderClass.azure.userAssignedIdentityID | quote }}
+    clientID: {{ .Values.secretProviderClass.azure.clientID | quote }}
     keyvaultName: {{ .Values.secretProviderClass.azure.keyvaultName | quote }}
     objects: |
       array:
@@ -25,7 +23,6 @@ spec:
           {{- end }}
         {{- end }}
     tenantId: {{ .Values.secretProviderClass.azure.tenantId | quote }}
-    {{- end }}
   {{- if .Values.secretProviderClass.secretObjects }}
   secretObjects:
     {{- range .Values.secretProviderClass.secretObjects }}


### PR DESCRIPTION
Updating default values, readme file and switching to workload id

```bash
helm template . | grep -A40 "kind: SecretProviderClass"
```

```yaml
kind: SecretProviderClass
metadata:
  name: "ffc-demo-apply-web"
  namespace: "default"
  labels:
    app: "default"
    app.kubernetes.io/name: "ffc-demo-apply-web"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/component: "web"
    app.kubernetes.io/part-of: "default"
    app.kubernetes.io/managed-by: "Helm"
    helm.sh/chart: ffc-demo-apply-web-1.0.0
spec:
  provider: "azure"
  parameters:
    usePodIdentity: "false"
    clientID: "your-client-id"
    keyvaultName: "your-keyvault-name"
    objects: |
      array:
        - |
          objectName: "database-password"
          objectType: "secret"
        - |
          objectName: "api-key"
          objectType: "secret"
          objectVersion: "latest"
    tenantId: "your-tenant-id"
  secretObjects:
    - secretName: "app-secrets"
      type: "Opaque"
      data:
        - objectName: "database-password"
          key: "DB_PASSWORD"
        - objectName: "api-key"
          key: "API_KEY"
```