### PR TITLE
Added csi volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ stringData:
 
 A K8s `SecretProviderClass` object for the Secrets Store CSI Driver. This template enables integration with external secret management systems like Azure Key Vault to mount secrets as volumes in pods, using [workload identity](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-microsoft-entra-workload-identity) for authentication.
 
+When `secretProviderClass` is configured, secrets from Azure Key Vault are automatically mounted as files at `/mnt/secrets-store` in all containers (Deployment, StatefulSet, and CronJob). Applications can read these secrets directly from the filesystem.
+
 A basic usage of this object template would involve the creation of `templates/secret-provider-class.yaml` in the parent Helm chart (e.g. `ffc-microservice`) containing:
 
 ```yaml

--- a/ffc-helm-library/Chart.yaml
+++ b/ffc-helm-library/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: ffc-helm-library
 description: A Helm library chart that captures general configuration for the FCP Kubernetes platform
 type: library
-version: 5.1.2
-
+version: 5.1.3

--- a/ffc-helm-library/templates/_container.yaml
+++ b/ffc-helm-library/templates/_container.yaml
@@ -83,6 +83,11 @@ ports:
 volumeMounts:
 - mountPath: /tmp
   name: temp-dir
+{{- if .Values.secretProviderClass }}
+- name: secrets-store
+  mountPath: /mnt/secrets-store
+  readOnly: true
+{{- end }}
 {{- end -}}
 {{- define "ffc-helm-library.container" -}}
 {{- println "" -}}

--- a/ffc-helm-library/templates/_cron-job.yaml
+++ b/ffc-helm-library/templates/_cron-job.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   schedule: {{ required (printf $requiredMsg "cronJob.schedule") .Values.cronJob.schedule | quote }}
   concurrencyPolicy: {{ required (printf $requiredMsg "cronJob.concurrencyPolicy") .Values.cronJob.concurrencyPolicy | quote }}
-  jobTemplate: 
+  jobTemplate:
     spec:
       template:
         metadata:
@@ -33,6 +33,14 @@ spec:
           volumes:
           - name: temp-dir
             emptyDir: {}
+          {{- if .Values.secretProviderClass }}
+          - name: secrets-store
+            csi:
+              driver: secrets-store.csi.x-k8s.io
+              readOnly: true
+              volumeAttributes:
+                secretProviderClass: {{ .Chart.Name | quote }}
+          {{- end }}
           {{- if .Values.workloadIdentity }}
           serviceAccountName: {{ .Chart.Name | quote }}
           {{- end }}

--- a/ffc-helm-library/templates/_deployment.yaml
+++ b/ffc-helm-library/templates/_deployment.yaml
@@ -60,6 +60,14 @@ spec:
       volumes:
       - name: temp-dir
         emptyDir: {}
+      {{- if .Values.secretProviderClass }}
+      - name: secrets-store
+        csi:
+          driver: secrets-store.csi.x-k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .Chart.Name | quote }}
+      {{- end }}
       containers:
       {{- if .Values.container }}
       - {{ include "ffc-helm-library.container" (list . (printf "%s.container" .Chart.Name )) }}

--- a/ffc-helm-library/templates/_statefulset.yaml
+++ b/ffc-helm-library/templates/_statefulset.yaml
@@ -45,6 +45,14 @@ spec:
       volumes:
       - name: temp-dir
         emptyDir: {}
+      {{- if .Values.secretProviderClass }}
+      - name: secrets-store
+        csi:
+          driver: secrets-store.csi.x-k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .Chart.Name | quote }}
+      {{- end }}
       containers:
       {{- if .Values.container }}
       - {{ include "ffc-helm-library.container" (list . (printf "%s.container" .Chart.Name )) }}


### PR DESCRIPTION
```bash
helm template . | grep -A113 "kind: Deployment"


kind: Deployment
metadata:
  labels:
    app: default
    app.kubernetes.io/component: web
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: ffc-demo-apply-web
    app.kubernetes.io/part-of: default
    app.kubernetes.io/version: 1.0.0
    helm.sh/chart: ffc-demo-apply-web-1.0.0
  name: ffc-demo-apply-web
  namespace: default
spec:
  minReadySeconds: 5
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: ffc-demo-apply-web
  strategy: {}
  template:
    metadata:
      annotations:
        config.linkerd.io/proxy-cpu-limit: 20m
        config.linkerd.io/proxy-cpu-request: 1m
        config.linkerd.io/proxy-memory-limit: 80Mi
        config.linkerd.io/proxy-memory-request: 10Mi
        linkerd.io/inject: enabled
        redeployOnChange: mBqF9
      labels:
        app: default
        app.kubernetes.io/component: web
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: ffc-demo-apply-web
        app.kubernetes.io/part-of: default
        app.kubernetes.io/version: 1.0.0
        azure.workload.identity/use: "true"
        helm.sh/chart: ffc-demo-apply-web-1.0.0
      namespace: default
    spec:
      automountServiceAccountToken: false
      containers:
      - envFrom:
        - configMapRef:
            name: ffc-demo-apply-web
        - secretRef:
            name: ffc-demo-apply-web
        image: ffc-demo-apply-web
        imagePullPolicy: Always
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /healthz
            port: 3000
          initialDelaySeconds: 30
          periodSeconds: 10
          timeoutSeconds: 5
        name: ffc-demo-apply-web
        ports:
        - containerPort: 3000
          name: http
          protocol: TCP
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /healthy
            port: 3000
          initialDelaySeconds: 20
          periodSeconds: 10
          timeoutSeconds: 5
        resources:
          limits:
            cpu: 80m
            memory: 80Mi
          requests:
            cpu: 10m
            memory: 10Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            add:
            - NET_BIND_SERVICE
            - SYS_TIME
            drop:
            - ALL
          readOnlyRootFilesystem: true
          seccompProfile:
            type: RuntimeDefault
        volumeMounts:
        - mountPath: /tmp
          name: temp-dir
        - mountPath: /mnt/secrets-store
          name: secrets-store
          readOnly: true
      priorityClassName: low
      restartPolicy: Always
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
      serviceAccountName: ffc-demo-apply-web
      volumes:
      - emptyDir: {}
        name: temp-dir
      - csi:
          driver: secrets-store.csi.x-k8s.io
          readOnly: true
          volumeAttributes:
            secretProviderClass: ffc-demo-apply-web
        name: secrets-store
---

```